### PR TITLE
Signup画面の作成

### DIFF
--- a/front/src/components/form/Auth.tsx
+++ b/front/src/components/form/Auth.tsx
@@ -1,4 +1,4 @@
-import { memo, VFC } from "react";
+import { memo, useState, VFC } from "react";
 import {
   Box,
   Center,
@@ -15,16 +15,26 @@ type Props = {
 
 export const Auth: VFC<Props> = memo((props) => {
   const { title } = props;
+  const [error, setError] = useState("")
+  const passwordConValidation = (values) => {
+    if (values.password !== values.passwordConf) {
+      setError("パスワードとパスワード（確認用）が異なります")
+    }
+  }
 
   return (
     <Formik
       initialValues={{name: "", email: "", password: "", passwordConf: ""}}
       onSubmit={(values) => {
+        if (title === "新規登録") {
+          passwordConValidation(values)
+        }
         console.log(values)
       }}
     >
       {({
         values,
+        errors,
         handleChange,
         handleSubmit
       }) => (
@@ -32,6 +42,15 @@ export const Auth: VFC<Props> = memo((props) => {
             <Center align="center" h="100vh">
               <Box w="335px">
                 <Heading as="h1" fontSize="md">{title}</Heading>
+                {title === "新規登録" && (
+                  <LabelInput
+                    name="name"
+                    value={values.name}
+                    onChange={handleChange}
+                  >
+                    ニックネーム
+                  </LabelInput>
+                )}
                 <LabelInput
                   type="email"
                   name="email"
@@ -48,6 +67,19 @@ export const Auth: VFC<Props> = memo((props) => {
                 >
                   パスワード
                 </LabelInput>
+                {title === "新規登録" && (
+                  <>
+                    <LabelInput
+                      type="password"
+                      name="passwordConf"
+                      value={values.passwordConf}
+                      onChange={handleChange}
+                    >
+                      パスワード（確認用）
+                    </LabelInput>
+                    <Text fontSize="xs" color="red.500">{error}</Text>
+                  </>
+                )}
                 <Box>
                   <BasicButton
                     backgroundColor="#FFA000"

--- a/front/src/pages/sign_up.tsx
+++ b/front/src/pages/sign_up.tsx
@@ -1,0 +1,13 @@
+import { memo, VFC } from "react"
+
+import { Auth } from "../components/form/Auth"
+
+const SignUp: VFC = memo(() => {
+  return (
+    <Auth
+      title="新規登録"
+    />
+  )
+})
+
+export default SignUp


### PR DESCRIPTION
## 概要
signup画面の作成
URL: http://localhost:3000/sign_up

## 仕様
- sign_inと基本同じ
- passwordとpasswordConfが異なる場合はエラーメッセージを表示

## 画面

https://user-images.githubusercontent.com/74091672/133064262-1f499e91-cd57-40cb-a15a-0956d079789e.mov

