### PR TITLE
本棚の情報を取得

### DIFF
--- a/front/src/components/BookGrid.tsx
+++ b/front/src/components/BookGrid.tsx
@@ -1,12 +1,22 @@
-import { Grid } from "@chakra-ui/react"
+import { Grid, Text } from "@chakra-ui/react"
+import axios from "axios"
+import { useEffect, useState } from "react"
+import { API_ENDPOINT } from "../utils/apiEndPoint"
 import { BookItem } from "./BookItem"
 
 export const BookGrid = () => {
-  const tmpBookContents = {
-    imageUrl: "/entertainment_comic.png",
-    title: "タイトルです",
-    bookId: "alice",
-  }
+  const [bookData, setBookData] = useState([])
+
+  useEffect(() => {
+    axios.get(`${API_ENDPOINT}/books`)
+    .then((res) => {
+      setBookData(res.data.books)
+    })
+    .catch((err) => {
+      console.log(err)
+    })
+  }, [])
+
   return (
     <Grid
       templateColumns="repeat(auto-fill, 150px)"
@@ -14,126 +24,22 @@ export const BookGrid = () => {
       gap={6}
       mx="auto"
     >
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
-      <BookItem
-        bookId={tmpBookContents.bookId}
-        title={tmpBookContents.title}
-        imageUrl={tmpBookContents.imageUrl}
-      />
+      {bookData.length ? (
+        <>
+          {bookData.map((data) => (
+            <BookItem
+              bookId={data.id}
+              title={data.title}
+              // unhandled runtime errorのため一旦コメントアウト
+              // imageUrl={data.epub_url}
+              imageUrl={"/entertainment_comic.png"}
+            />
+          ))}
+        </>
+      ) : (
+        <Text>本棚に本がありません</Text>
+      )
+      }
     </Grid>
   )
 }

--- a/front/src/components/BookGrid.tsx
+++ b/front/src/components/BookGrid.tsx
@@ -30,9 +30,7 @@ export const BookGrid = () => {
             <BookItem
               bookId={data.id}
               title={data.title}
-              // unhandled runtime errorのため一旦コメントアウト
-              // imageUrl={data.epub_url}
-              imageUrl={"/entertainment_comic.png"}
+              imageUrl={data.epub_url}
             />
           ))}
         </>

--- a/front/src/components/BookItem.tsx
+++ b/front/src/components/BookItem.tsx
@@ -7,6 +7,10 @@ import {
   Stack,
   Text,
 } from "@chakra-ui/react"
+import axios from "axios"
+
+import { API_ENDPOINT } from "../utils/apiEndPoint"
+import { useState } from "react"
 
 type BookItemProps = {
   imageUrl: string
@@ -18,6 +22,18 @@ export const BookItem: React.FC<BookItemProps> = ({
   title,
   bookId,
 }) => {
+  const [epubUrl, setEpubUrl] = useState("")
+
+  const handleClickGetEpub = () => {
+    axios.get(`${API_ENDPOINT}/${bookId}/epub`)
+    .then((res) => {
+      setEpubUrl(res.data.epub_url)
+    })
+    .catch((err) => {
+      console.log(err)
+    })
+  }
+
   return (
     <Stack>
       <LinkBox>
@@ -27,7 +43,7 @@ export const BookItem: React.FC<BookItemProps> = ({
           <Box bg="tomato" width="150px" height="240px"></Box>
         )}
         <Center>
-          <LinkOverlay href={"/read/" + bookId}>
+          <LinkOverlay onClick={handleClickGetEpub} href="/read/alice">
             <Text textDecoration="none">{title}</Text>
           </LinkOverlay>
         </Center>

--- a/front/src/components/BookItem.tsx
+++ b/front/src/components/BookItem.tsx
@@ -1,9 +1,9 @@
-import Image from "next/image"
 import {
   Box,
   Center,
   LinkBox,
   LinkOverlay,
+  Image,
   Stack,
   Text,
 } from "@chakra-ui/react"

--- a/front/src/components/BookItem.tsx
+++ b/front/src/components/BookItem.tsx
@@ -7,10 +7,6 @@ import {
   Stack,
   Text,
 } from "@chakra-ui/react"
-import axios from "axios"
-
-import { API_ENDPOINT } from "../utils/apiEndPoint"
-import { useState } from "react"
 
 type BookItemProps = {
   imageUrl: string
@@ -22,18 +18,6 @@ export const BookItem: React.FC<BookItemProps> = ({
   title,
   bookId,
 }) => {
-  const [epubUrl, setEpubUrl] = useState("")
-
-  const handleClickGetEpub = () => {
-    axios.get(`${API_ENDPOINT}/${bookId}/epub`)
-    .then((res) => {
-      setEpubUrl(res.data.epub_url)
-    })
-    .catch((err) => {
-      console.log(err)
-    })
-  }
-
   return (
     <Stack>
       <LinkBox>
@@ -43,7 +27,7 @@ export const BookItem: React.FC<BookItemProps> = ({
           <Box bg="tomato" width="150px" height="240px"></Box>
         )}
         <Center>
-          <LinkOverlay onClick={handleClickGetEpub} href="/read/alice">
+          <LinkOverlay href={`/read/${bookId}`}>
             <Text textDecoration="none">{title}</Text>
           </LinkOverlay>
         </Center>

--- a/front/src/components/Reader.tsx
+++ b/front/src/components/Reader.tsx
@@ -1,5 +1,8 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { ReactReader } from "react-reader"
+import axios from "axios"
+
+import { API_ENDPOINT } from "../utils/apiEndPoint"
 
 type ReaderProps = {
   id: string
@@ -8,16 +11,28 @@ type ReaderProps = {
 const Reader: React.FC<ReaderProps> = ({ id }) => {
   // And your own state logic to persist state
   const [location, setLocation] = useState(null)
+  const [epubUrl, setEpubUrl] = useState("")
   const locationChanged = (epubcifi) => {
     // epubcifi is a internal string used by epubjs to point to a location in an epub. It looks like this: epubcfi(/6/6[titlepage]!/4/2/12[pgepubid00003]/3:0)
     setLocation(epubcifi)
   }
+
+  useEffect(() => {
+    axios.get(`${API_ENDPOINT}/books/${id}/epub`)
+    .then((res) => {
+      setEpubUrl(res.data.epub_url)
+    })
+    .catch((err) => {
+      console.log(err)
+    })
+  }, [])
+
   return (
     <div style={{ height: "100vh" }}>
       <ReactReader
         location={location}
         locationChanged={locationChanged}
-        url={"/" + id + ".epub"}
+        url={epubUrl}
       />
     </div>
   )


### PR DESCRIPTION
## 概要
本棚の情報を取得
URL：http:localhost:3000/shelf

## 仕様
- アクセスした時に本棚の情報を取得
- 本をクリックするとepubURLを取得

## 画面

https://user-images.githubusercontent.com/74091672/133208828-52b71ea5-2ca4-42cb-98c2-405241db294b.mov

## その他
- バックエンドに情報の修正を依頼したい
  - サムネ画像がruntimeエラーで読み込めない
  - epubURLの情報を現行の`http://example.com`から`alice`などにする
    - これは現状の仕様ではpublic配下のepubファイルを読み込んでいるからpublic配下になくても読み込めるようにするにはどうすればいいんだろう。。

![スクリーンショット 2021-09-14 15 48 39](https://user-images.githubusercontent.com/74091672/133208991-33f4dec1-8ad5-4e28-bef2-f317dff7b443.png)

