### PR TITLE
イベント本棚

### DIFF
--- a/front/src/components/book/AddBook.tsx
+++ b/front/src/components/book/AddBook.tsx
@@ -18,7 +18,7 @@ export const AddBook: VFC<Props> = memo((props) => {
 
   const handleClickAddBook = () => {
     axios
-      .post(`${API_ENDPOINT}/books`, { id })
+      .post(`${API_ENDPOINT}/users/me/books`, { id })
       .then(() => {
         router.push("/shelf")
         showMessage({ title: "本棚に追加しました", status: "success" })

--- a/front/src/components/book/BookGrid.tsx
+++ b/front/src/components/book/BookGrid.tsx
@@ -4,19 +4,36 @@ import { useEffect, useState } from "react"
 import { API_ENDPOINT } from "../../utils/apiEndPoint"
 import { BookItem } from "./BookItem"
 
-export const BookGrid = () => {
+type BookGridProps = {
+  eventId: string
+}
+
+export const BookGrid: React.FC<BookGridProps> = ({ eventId }) => {
   const [bookData, setBookData] = useState([])
 
   useEffect(() => {
-    axios
-      .get(`${API_ENDPOINT}/books`)
-      .then((res) => {
-        setBookData(res.data.books)
-      })
-      .catch((err) => {
-        console.log(err)
-      })
-  }, [])
+    if (eventId != null) {
+      axios
+        .get(`${API_ENDPOINT}/users/me/event/${eventId}/books`)
+        .then((res) => {
+          console.log(res)
+          setBookData(res.data)
+        })
+        .catch((err) => {
+          console.log(err)
+        })
+    } else {
+      axios
+        .get(`${API_ENDPOINT}/users/me/books`)
+        .then((res) => {
+          console.log(res)
+          setBookData(res.data)
+        })
+        .catch((err) => {
+          console.log(err)
+        })
+    }
+  }, [eventId])
 
   return (
     <Grid
@@ -29,9 +46,10 @@ export const BookGrid = () => {
         <>
           {bookData.map((data) => (
             <BookItem
-              bookId={data.id}
+              bookId={data.ID}
               title={data.Title}
-              imageUrl={data.test1}
+              imageUrl={data.Thumbnailurl}
+              canAccess={data.CanAccess}
             />
           ))}
         </>

--- a/front/src/components/book/BookGrid.tsx
+++ b/front/src/components/book/BookGrid.tsx
@@ -16,7 +16,6 @@ export const BookGrid: React.FC<BookGridProps> = ({ eventId }) => {
       axios
         .get(`${API_ENDPOINT}/users/me/event/${eventId}/books`)
         .then((res) => {
-          console.log(res)
           setBookData(res.data)
         })
         .catch((err) => {
@@ -26,7 +25,6 @@ export const BookGrid: React.FC<BookGridProps> = ({ eventId }) => {
       axios
         .get(`${API_ENDPOINT}/users/me/books`)
         .then((res) => {
-          console.log(res)
           setBookData(res.data)
         })
         .catch((err) => {
@@ -42,7 +40,7 @@ export const BookGrid: React.FC<BookGridProps> = ({ eventId }) => {
       gap={6}
       mx="auto"
     >
-      {bookData.length ? (
+      {bookData && bookData.length ? (
         <>
           {bookData.map((data) => (
             <BookItem
@@ -54,7 +52,7 @@ export const BookGrid: React.FC<BookGridProps> = ({ eventId }) => {
           ))}
         </>
       ) : (
-        <Text>本棚に本がありません</Text>
+        <Text>本がありません</Text>
       )}
     </Grid>
   )

--- a/front/src/components/book/BookItem.tsx
+++ b/front/src/components/book/BookItem.tsx
@@ -33,14 +33,16 @@ export const BookItem: React.FC<BookItemProps> = ({
     <Stack>
       <LinkBox>
         <Container p="0" position="relative" maxW="100%" height="auto">
-          {imageUrl != "" ? (
-            <Image src={imageUrl} alt={title} width={150} height={240} />
+          {canAccess && imageUrl != "" ? (
+            <>
+              <Image src={imageUrl} alt={title} width={150} height={240} />
+              <Box position="absolute" zIndex="1" top={0} right={2}>
+                <FavStar isFav={isFav} onClick={onClickFav} />
+              </Box>
+            </>
           ) : (
-            <Box bg="tomato" width="150px" height="240px"></Box>
+            <Box bg="gray.200" width="150px" height="240px"></Box>
           )}
-          <Box position="absolute" zIndex="1" top={0} right={2}>
-            <FavStar isFav={isFav} onClick={onClickFav} />
-          </Box>
         </Container>
         <Center>
           {canAccess ? (

--- a/front/src/components/book/BookItem.tsx
+++ b/front/src/components/book/BookItem.tsx
@@ -15,11 +15,13 @@ type BookItemProps = {
   imageUrl: string
   title: string
   bookId: string
+  canAccess: boolean
 }
 export const BookItem: React.FC<BookItemProps> = ({
   imageUrl,
   title,
   bookId,
+  canAccess,
 }) => {
   const [isFav, setIsFav] = useState<boolean>(false)
 
@@ -41,9 +43,13 @@ export const BookItem: React.FC<BookItemProps> = ({
           </Box>
         </Container>
         <Center>
-          <LinkOverlay href={`/read/${bookId}`}>
+          {canAccess ? (
+            <LinkOverlay href={`/read/${bookId}`}>
+              <Text textDecoration="none">{title}</Text>
+            </LinkOverlay>
+          ) : (
             <Text textDecoration="none">{title}</Text>
-          </LinkOverlay>
+          )}
         </Center>
       </LinkBox>
     </Stack>

--- a/front/src/components/book/BookItem.tsx
+++ b/front/src/components/book/BookItem.tsx
@@ -25,6 +25,8 @@ export const BookItem: React.FC<BookItemProps> = ({
 }) => {
   const [isFav, setIsFav] = useState<boolean>(false)
 
+  const cannotAccess = canAccess != null && !canAccess
+
   const onClickFav = () => {
     setIsFav((prev) => !prev)
   }
@@ -33,7 +35,7 @@ export const BookItem: React.FC<BookItemProps> = ({
     <Stack>
       <LinkBox>
         <Container p="0" position="relative" maxW="100%" height="auto">
-          {canAccess && imageUrl != "" ? (
+          {!cannotAccess && imageUrl != "" ? (
             <>
               <Image src={imageUrl} alt={title} width={150} height={240} />
               <Box position="absolute" zIndex="1" top={0} right={2}>
@@ -45,7 +47,7 @@ export const BookItem: React.FC<BookItemProps> = ({
           )}
         </Container>
         <Center>
-          {canAccess ? (
+          {!cannotAccess ? (
             <LinkOverlay href={`/read/${bookId}`}>
               <Text textDecoration="none">{title}</Text>
             </LinkOverlay>

--- a/front/src/components/book/BookShelf.tsx
+++ b/front/src/components/book/BookShelf.tsx
@@ -1,7 +1,11 @@
 import { Box, Input, Center, Heading, Stack } from "@chakra-ui/react"
 import { BookGrid } from "./BookGrid"
 
-export const BookShelf = () => {
+type BookShelf = {
+  eventId: string
+}
+
+export const BookShelf = ({ eventId }) => {
   return (
     <Box>
       <Center>
@@ -12,7 +16,7 @@ export const BookShelf = () => {
           <Center>
             <Input width="80%" placeholder="本や作者を検索" />
           </Center>
-          <BookGrid />
+          <BookGrid eventId={eventId} />
         </Stack>
       </Center>
     </Box>

--- a/front/src/components/map/MapInfo.tsx
+++ b/front/src/components/map/MapInfo.tsx
@@ -30,7 +30,7 @@ export const MapInfo: React.FC<EventProps> = ({ event }) => {
         {event.endDate.toLocaleDateString()}
       </Text>
       <Text textAlign="right" color="#ffa000">
-        <Link href="/shelf">漫画を見る→</Link>
+        <Link href={`/shelf?event=${event.id}`}>漫画を見る→</Link>
       </Text>
     </Box>
   )

--- a/front/src/pages/shelf/index.tsx
+++ b/front/src/pages/shelf/index.tsx
@@ -1,7 +1,11 @@
+import { useRouter } from "next/router"
 import { BookShelf } from "../../components/book/BookShelf"
+import { getAsStringFromArray } from "../../utils/getAsStringFromArray"
 
 const App = () => {
-  return <BookShelf />
+  const router = useRouter()
+  const eventId = getAsStringFromArray(router.query.event)
+  return <BookShelf eventId={eventId} />
 }
 
 export default App


### PR DESCRIPTION
## やったこと

http://localhost:3000/shelf?event=1
でイベントid1の本棚にアクセス

マップもそのイベントのidの本棚にアクセスするよう修正

イベント別に見た時は持っていない本も表示したいので、その表示わけ
<img width="376" alt="スクリーンショット 2021-09-15 11 58 15" src="https://user-images.githubusercontent.com/44559810/133363220-5f487db0-f0d4-4e28-b712-7c2c88bf6e40.png">

## 注釈

本棚にもイベント名出したい気持ち。